### PR TITLE
Design tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
-# Created by https://www.toptal.com/developers/gitignore/api/macos,cocoapods,swiftpackagemanager,carthage,swift,xcode
-# Edit at https://www.toptal.com/developers/gitignore?templates=macos,cocoapods,swiftpackagemanager,carthage,swift,xcode
+# Created by https://www.toptal.com/developers/gitignore/api/cocoapods,objective-c,macos,carthage
+# Edit at https://www.toptal.com/developers/gitignore?templates=cocoapods,objective-c,macos,carthage
 
 ### Carthage ###
 # Carthage
@@ -47,7 +47,7 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-### Swift ###
+### Objective-C ###
 # Xcode
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
@@ -79,22 +79,6 @@ DerivedData/
 *.dSYM.zip
 *.dSYM
 
-## Playgrounds
-timeline.xctimeline
-playground.xcworkspace
-
-# Swift Package Manager
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
-# Package.resolved
-# *.xcodeproj
-# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
-# hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
-
-.build/
-
 # CocoaPods
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
@@ -108,10 +92,6 @@ playground.xcworkspace
 # Carthage/Checkouts
 
 Carthage/Build/
-
-# Accio dependency management
-Dependencies/
-.accio/
 
 # fastlane
 # It is recommended to not store the screenshots in the git repo.
@@ -130,22 +110,7 @@ fastlane/test_output
 
 iOSInjectionProject/
 
-### SwiftPackageManager ###
-Packages
-xcuserdata
-*.xcodeproj
+### Objective-C Patch ###
 
+# End of https://www.toptal.com/developers/gitignore/api/cocoapods,objective-c,macos,carthage
 
-### Xcode ###
-
-## Xcode 8 and earlier
-
-### Xcode Patch ###
-*.xcodeproj/*
-!*.xcodeproj/project.pbxproj
-!*.xcodeproj/xcshareddata/
-!*.xcworkspace/contents.xcworkspacedata
-/*.gcno
-**/xcshareddata/WorkspaceSettings.xcsettings
-
-# End of https://www.toptal.com/developers/gitignore/api/macos,cocoapods,swiftpackagemanager,carthage,swift,xcode

--- a/HandsOnWatch WatchKit Extension/ContentView.swift
+++ b/HandsOnWatch WatchKit Extension/ContentView.swift
@@ -13,27 +13,7 @@ struct ContentView: View {
     var body: some View {
         NavigationView {
             ScrollView {
-                VStack(spacing: 10) {
-                    VStack {
-                        Rectangle()
-                            .fill(DesignTokens.Colors.Brand.primaryColor)
-                            .cornerRadius(8)
-                            .frame(height: DesignTokens.Card.cardHeight)
-                            .padding(.horizontal, 5)
-                        
-                        Rectangle()
-                            .fill(DesignTokens.Colors.Support.primaryColor)
-                            .cornerRadius(8)
-                            .frame(height: DesignTokens.Card.cardHeight)
-                            .padding(.horizontal, 5)
-                        
-                        Rectangle()
-                            .fill(DesignTokens.Colors.Support.secondaryColor)
-                            .cornerRadius(8)
-                            .frame(height: DesignTokens.Card.cardHeight)
-                            .padding(.horizontal, 5)
-                    }
-                }
+                
             }
             .background(.gray)
         }

--- a/HandsOnWatch WatchKit Extension/ContentView.swift
+++ b/HandsOnWatch WatchKit Extension/ContentView.swift
@@ -6,11 +6,40 @@
 //
 
 import SwiftUI
+import WatchKit
 
 struct ContentView: View {
+    
     var body: some View {
-        Text("Hello, World!")
-            .padding()
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 10) {
+                    VStack {
+                        Rectangle()
+                            .fill(DesignTokens.Colors.Brand.primaryColor)
+                            .cornerRadius(8)
+                            .frame(height: DesignTokens.Card.cardHeight)
+                            .padding(.horizontal, 5)
+                        
+                        Rectangle()
+                            .fill(DesignTokens.Colors.Support.primaryColor)
+                            .cornerRadius(8)
+                            .frame(height: DesignTokens.Card.cardHeight)
+                            .padding(.horizontal, 5)
+                        
+                        Rectangle()
+                            .fill(DesignTokens.Colors.Support.secondaryColor)
+                            .cornerRadius(8)
+                            .frame(height: DesignTokens.Card.cardHeight)
+                            .padding(.horizontal, 5)
+                    }
+                }
+            }
+            .background(.gray)
+        }
+        .navigationTitle("Flemis")
+        .navigationBarTitleDisplayMode(.inline)
+
     }
 }
 

--- a/HandsOnWatch WatchKit Extension/ContentView.swift
+++ b/HandsOnWatch WatchKit Extension/ContentView.swift
@@ -10,10 +10,11 @@ import WatchKit
 
 struct ContentView: View {
     
+    
+    
     var body: some View {
         NavigationView {
             ScrollView {
-                
             }
             .background(.gray)
         }

--- a/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
+++ b/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
@@ -12,7 +12,7 @@ import SwiftUI
 enum DesignTokens {
     
     //MARK: - Colors
-    enum Colors {
+    enum Colors: CaseIterable {
         
         enum Brand {
             
@@ -21,7 +21,7 @@ enum DesignTokens {
             }
         }
         
-        enum Support {
+        enum Support: CaseIterable {
             
             static var primaryColor: Color {
                 return Color(red: 0.98, green: 0.067, blue: 0.31)
@@ -40,7 +40,7 @@ enum DesignTokens {
             }
         }
         
-        enum Neutral {
+        enum Neutral: CaseIterable {
             
             static var lowPure: Color {
                 return Color(red: 0, green: 0, blue: 0)
@@ -82,7 +82,7 @@ enum DesignTokens {
     
     //MARK: - Border Radius
     
-    enum BorderRadius {
+    enum BorderRadius: CaseIterable {
         
         static var none: CGFloat = {
             return 0
@@ -102,6 +102,35 @@ enum DesignTokens {
     }
     
     //MARK: - Icons
+    
+    enum Icons: CaseIterable {
+        
+        static var minusFill: Image = {
+            Image(systemName: "minus.circle.fill")
+                .frame(width: 24, height: 24)
+        }() as! Image
+        
+        static var plusFill: Image = {
+            Image(systemName: "plus.circle.fill")
+                .frame(width: 24, height: 24)
+        }() as! Image
+        
+        static var xmarkFill: Image = {
+            Image(systemName: "xmark.circle.fill")
+                .frame(width: 32, height: 32)
+        }() as! Image
+        
+        static var pauseFill: Image = {
+            Image(systemName: "pause.circle.fill")
+                .frame(width: 32, height: 32)
+                
+        }() as! Image
+        
+        static var ellipsisFill: Image = {
+            Image(systemName: "ellipsi.circle.fill")
+                .frame(width: 18, height: 18)
+        }() as! Image
+    }
     
     //MARK: - Opacity
 }

--- a/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
+++ b/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
@@ -80,7 +80,26 @@ enum DesignTokens {
     
     //MARK: - Fonts
     
-    //MARK: - Corner Radius
+    //MARK: - Border Radius
+    
+    enum BorderRadius {
+        
+        static var none: CGFloat = {
+            return 0
+        }()
+        
+        static var sm: CGFloat = {
+            return 8
+        }()
+        
+        static var pill: CGFloat = {
+            return 34.44
+        }()
+        
+        static var circular: CGFloat = {
+           return 100
+        }()
+    }
     
     //MARK: - Icons
     

--- a/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
+++ b/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 import SwiftUI
 
 //MARK: - Hands On Design System
@@ -80,6 +81,28 @@ enum DesignTokens {
     
     //MARK: - Fonts
     
+    enum Fonts {
+        
+        static var measures: Font = {
+            return Font(Font.system(size: 40).weight(.semibold) as! CTFont)
+        }()
+        
+        /**
+            Used for description-text token
+         
+            primary-description-text uses **support** colors
+         
+            secondary-description-text uses **neutral** colors
+         */
+        static var description: Font = {
+            return Font(Font.system(size: 15).weight(.regular) as! CTFont).uppercaseSmallCaps()
+        }()
+        
+        static var totalTime: Font = {
+            return Font(Font.system(size: 14).weight(.regular) as! CTFont).uppercaseSmallCaps()
+        }()
+    }
+    
     //MARK: - Border Radius
     
     enum BorderRadius: CaseIterable {
@@ -107,28 +130,27 @@ enum DesignTokens {
         
         static var minusFill: Image = {
             Image(systemName: "minus.circle.fill")
-                .frame(width: 24, height: 24)
+                .font(Font.system(size: 24).weight(.light))
         }() as! Image
         
         static var plusFill: Image = {
             Image(systemName: "plus.circle.fill")
-                .frame(width: 24, height: 24)
+                .font(Font.system(size: 24).weight(.light))
         }() as! Image
         
         static var xmarkFill: Image = {
             Image(systemName: "xmark.circle.fill")
-                .frame(width: 32, height: 32)
+                .font(Font.system(size: 32).weight(.light))
         }() as! Image
         
         static var pauseFill: Image = {
             Image(systemName: "pause.circle.fill")
-                .frame(width: 32, height: 32)
-                
+                .font(Font.system(size: 32).weight(.light))
         }() as! Image
         
         static var ellipsisFill: Image = {
             Image(systemName: "ellipsi.circle.fill")
-                .frame(width: 18, height: 18)
+                .font(Font.system(size: 18).weight(.light))
         }() as! Image
     }
     

--- a/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
+++ b/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
@@ -1,0 +1,88 @@
+//
+//  Design-Tokens.swift
+//  HandsOnWatch WatchKit Extension
+//
+//  Created by Marina De Pazzi on 05/04/22.
+//
+
+import Foundation
+import SwiftUI
+
+//MARK: - Hands On Design System
+enum DesignTokens {
+    
+    //MARK: - Colors
+    enum Colors {
+        
+        enum Brand {
+            
+            static var primaryColor: Color {
+                return Color(red: 0.471, green: 0.478, blue: 1)
+            }
+        }
+        
+        enum Support {
+            
+            static var primaryColor: Color {
+                return Color(red: 0.98, green: 0.067, blue: 0.31)
+            }
+            
+            static var secondaryColor: Color {
+                return Color(red: 0.016, green: 0.871, blue: 0.443)
+            }
+            
+            static var tertiaryColor: Color {
+                return Color(red: 1, green: 0.584, blue: 0)
+            }
+            
+            static var quaternaryColor: Color {
+                return Color(red: 0.353, green: 0.784, blue: 0.98)
+            }
+        }
+        
+        enum Neutral {
+            
+            static var lowPure: Color {
+                return Color(red: 0, green: 0, blue: 0)
+            }
+            
+            static var lowDark: Color {
+                return Color(red: 0.3, green: 0.3, blue: 0.3)
+            }
+            
+            static var lowLight: Color {
+                return Color(red: 0.608, green: 0.608, blue: 0.608)
+            }
+            
+            static var highPure: Color {
+                return Color(red: 1, green: 1, blue: 1)
+            }
+            
+            static var highDark: Color {
+                return Color(red: 0.75, green: 0.75, blue: 0.75)
+            }
+            
+            static var highLight: Color {
+                return Color(red: 0.871, green: 0.871, blue: 0.871)
+            }
+        }
+    }
+    
+    //MARK: - ComponentDimensions
+    
+    enum ComponentDimensions {
+        enum Card {
+            static var cardHeight: CGFloat = {
+                return WKInterfaceDevice.current().screenBounds.size.height * 0.36
+            }()
+        }
+    }
+    
+    //MARK: - Fonts
+    
+    //MARK: - Corner Radius
+    
+    //MARK: - Icons
+    
+    //MARK: - Opacity
+}

--- a/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
+++ b/HandsOnWatch WatchKit Extension/Views/Components/Design-Tokens.swift
@@ -18,7 +18,7 @@ enum DesignTokens {
         enum Brand {
             
             static var primaryColor: Color {
-                return Color(red: 0.471, green: 0.478, blue: 1)
+                return Color(red: 1, green: 0.36, blue: 0)
             }
         }
         

--- a/HandsOnWatch.xcodeproj/project.pbxproj
+++ b/HandsOnWatch.xcodeproj/project.pbxproj
@@ -1,0 +1,607 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		1BBD6E2D27FB84D400489427 /* HandsOnWatch WatchKit App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 1BBD6E2C27FB84D400489427 /* HandsOnWatch WatchKit App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1BBD6E3227FB84D900489427 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BBD6E3127FB84D900489427 /* Assets.xcassets */; };
+		1BBD6E3827FB84D900489427 /* HandsOnWatch WatchKit Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 1BBD6E3727FB84D900489427 /* HandsOnWatch WatchKit Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1BBD6E3D27FB84D900489427 /* HandsOnWatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E3C27FB84D900489427 /* HandsOnWatchApp.swift */; };
+		1BBD6E3F27FB84D900489427 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E3E27FB84D900489427 /* ContentView.swift */; };
+		1BBD6E4127FB84D900489427 /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E4027FB84D900489427 /* NotificationController.swift */; };
+		1BBD6E4327FB84D900489427 /* NotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E4227FB84D900489427 /* NotificationView.swift */; };
+		1BBD6E4527FB84D900489427 /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E4427FB84D900489427 /* ComplicationController.swift */; };
+		1BBD6E4727FB84DA00489427 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BBD6E4627FB84DA00489427 /* Assets.xcassets */; };
+		1BBD6E4A27FB84DA00489427 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BBD6E4927FB84DA00489427 /* Preview Assets.xcassets */; };
+		1BBD6E5D27FCBFA300489427 /* Design-Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBD6E5C27FCBFA300489427 /* Design-Tokens.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1BBD6E2E27FB84D400489427 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1BBD6E2227FB84D300489427 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1BBD6E2B27FB84D400489427;
+			remoteInfo = "HandsOnWatch WatchKit App";
+		};
+		1BBD6E3927FB84D900489427 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1BBD6E2227FB84D300489427 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1BBD6E3627FB84D900489427;
+			remoteInfo = "HandsOnWatch WatchKit Extension";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1BBD6E5227FB84DA00489427 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				1BBD6E3827FB84D900489427 /* HandsOnWatch WatchKit Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1BBD6E5627FB84DA00489427 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				1BBD6E2D27FB84D400489427 /* HandsOnWatch WatchKit App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		1BBD6E2827FB84D400489427 /* HandsOnWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HandsOnWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BBD6E2C27FB84D400489427 /* HandsOnWatch WatchKit App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "HandsOnWatch WatchKit App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BBD6E3127FB84D900489427 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1BBD6E3727FB84D900489427 /* HandsOnWatch WatchKit Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "HandsOnWatch WatchKit Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BBD6E3C27FB84D900489427 /* HandsOnWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandsOnWatchApp.swift; sourceTree = "<group>"; };
+		1BBD6E3E27FB84D900489427 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		1BBD6E4027FB84D900489427 /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		1BBD6E4227FB84D900489427 /* NotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationView.swift; sourceTree = "<group>"; };
+		1BBD6E4427FB84D900489427 /* ComplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationController.swift; sourceTree = "<group>"; };
+		1BBD6E4627FB84DA00489427 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1BBD6E4927FB84DA00489427 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		1BBD6E4B27FB84DA00489427 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1BBD6E4C27FB84DA00489427 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		1BBD6E5C27FCBFA300489427 /* Design-Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Design-Tokens.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1BBD6E3427FB84D900489427 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1BBD6E2127FB84D300489427 = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E3027FB84D400489427 /* HandsOnWatch WatchKit App */,
+				1BBD6E3B27FB84D900489427 /* HandsOnWatch WatchKit Extension */,
+				1BBD6E2927FB84D400489427 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1BBD6E2927FB84D400489427 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E2827FB84D400489427 /* HandsOnWatch.app */,
+				1BBD6E2C27FB84D400489427 /* HandsOnWatch WatchKit App.app */,
+				1BBD6E3727FB84D900489427 /* HandsOnWatch WatchKit Extension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		1BBD6E3027FB84D400489427 /* HandsOnWatch WatchKit App */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E3127FB84D900489427 /* Assets.xcassets */,
+			);
+			path = "HandsOnWatch WatchKit App";
+			sourceTree = "<group>";
+		};
+		1BBD6E3B27FB84D900489427 /* HandsOnWatch WatchKit Extension */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E5A27FCBF8B00489427 /* Views */,
+				1BBD6E3C27FB84D900489427 /* HandsOnWatchApp.swift */,
+				1BBD6E3E27FB84D900489427 /* ContentView.swift */,
+				1BBD6E4027FB84D900489427 /* NotificationController.swift */,
+				1BBD6E4227FB84D900489427 /* NotificationView.swift */,
+				1BBD6E4427FB84D900489427 /* ComplicationController.swift */,
+				1BBD6E4627FB84DA00489427 /* Assets.xcassets */,
+				1BBD6E4B27FB84DA00489427 /* Info.plist */,
+				1BBD6E4C27FB84DA00489427 /* PushNotificationPayload.apns */,
+				1BBD6E4827FB84DA00489427 /* Preview Content */,
+			);
+			path = "HandsOnWatch WatchKit Extension";
+			sourceTree = "<group>";
+		};
+		1BBD6E4827FB84DA00489427 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E4927FB84DA00489427 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		1BBD6E5A27FCBF8B00489427 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E5B27FCBF9200489427 /* Components */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		1BBD6E5B27FCBF9200489427 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				1BBD6E5C27FCBFA300489427 /* Design-Tokens.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1BBD6E2727FB84D300489427 /* HandsOnWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1BBD6E5727FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch" */;
+			buildPhases = (
+				1BBD6E2627FB84D300489427 /* Resources */,
+				1BBD6E5627FB84DA00489427 /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1BBD6E2F27FB84D400489427 /* PBXTargetDependency */,
+			);
+			name = HandsOnWatch;
+			productName = HandsOnWatch;
+			productReference = 1BBD6E2827FB84D400489427 /* HandsOnWatch.app */;
+			productType = "com.apple.product-type.application.watchapp2-container";
+		};
+		1BBD6E2B27FB84D400489427 /* HandsOnWatch WatchKit App */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1BBD6E5327FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch WatchKit App" */;
+			buildPhases = (
+				1BBD6E2A27FB84D400489427 /* Resources */,
+				1BBD6E5227FB84DA00489427 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1BBD6E3A27FB84D900489427 /* PBXTargetDependency */,
+			);
+			name = "HandsOnWatch WatchKit App";
+			productName = "HandsOnWatch WatchKit App";
+			productReference = 1BBD6E2C27FB84D400489427 /* HandsOnWatch WatchKit App.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		1BBD6E3627FB84D900489427 /* HandsOnWatch WatchKit Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1BBD6E4F27FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch WatchKit Extension" */;
+			buildPhases = (
+				1BBD6E3327FB84D900489427 /* Sources */,
+				1BBD6E3427FB84D900489427 /* Frameworks */,
+				1BBD6E3527FB84D900489427 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "HandsOnWatch WatchKit Extension";
+			productName = "HandsOnWatch WatchKit Extension";
+			productReference = 1BBD6E3727FB84D900489427 /* HandsOnWatch WatchKit Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1BBD6E2227FB84D300489427 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1330;
+				LastUpgradeCheck = 1330;
+				TargetAttributes = {
+					1BBD6E2727FB84D300489427 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					1BBD6E2B27FB84D400489427 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+					1BBD6E3627FB84D900489427 = {
+						CreatedOnToolsVersion = 13.3;
+					};
+				};
+			};
+			buildConfigurationList = 1BBD6E2527FB84D300489427 /* Build configuration list for PBXProject "HandsOnWatch" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1BBD6E2127FB84D300489427;
+			productRefGroup = 1BBD6E2927FB84D400489427 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1BBD6E2727FB84D300489427 /* HandsOnWatch */,
+				1BBD6E2B27FB84D400489427 /* HandsOnWatch WatchKit App */,
+				1BBD6E3627FB84D900489427 /* HandsOnWatch WatchKit Extension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1BBD6E2627FB84D300489427 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1BBD6E2A27FB84D400489427 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BBD6E3227FB84D900489427 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1BBD6E3527FB84D900489427 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BBD6E4A27FB84DA00489427 /* Preview Assets.xcassets in Resources */,
+				1BBD6E4727FB84DA00489427 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1BBD6E3327FB84D900489427 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1BBD6E4127FB84D900489427 /* NotificationController.swift in Sources */,
+				1BBD6E3F27FB84D900489427 /* ContentView.swift in Sources */,
+				1BBD6E4527FB84D900489427 /* ComplicationController.swift in Sources */,
+				1BBD6E5D27FCBFA300489427 /* Design-Tokens.swift in Sources */,
+				1BBD6E3D27FB84D900489427 /* HandsOnWatchApp.swift in Sources */,
+				1BBD6E4327FB84D900489427 /* NotificationView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1BBD6E2F27FB84D400489427 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1BBD6E2B27FB84D400489427 /* HandsOnWatch WatchKit App */;
+			targetProxy = 1BBD6E2E27FB84D400489427 /* PBXContainerItemProxy */;
+		};
+		1BBD6E3A27FB84D900489427 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1BBD6E3627FB84D900489427 /* HandsOnWatch WatchKit Extension */;
+			targetProxy = 1BBD6E3927FB84D900489427 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		1BBD6E4D27FB84DA00489427 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1BBD6E4E27FB84DA00489427 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1BBD6E5027FB84DA00489427 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"HandsOnWatch WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = GYMDP69744;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "HandsOnWatch WatchKit Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "HandsOnWatch WatchKit Extension";
+				INFOPLIST_KEY_CLKComplicationPrincipalClass = "$(PRODUCT_MODULE_NAME).ComplicationController";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Debug;
+		};
+		1BBD6E5127FB84DA00489427 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"HandsOnWatch WatchKit Extension/Preview Content\"";
+				DEVELOPMENT_TEAM = GYMDP69744;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "HandsOnWatch WatchKit Extension/Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "HandsOnWatch WatchKit Extension";
+				INFOPLIST_KEY_CLKComplicationPrincipalClass = "$(PRODUCT_MODULE_NAME).ComplicationController";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_WKWatchOnly = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Release;
+		};
+		1BBD6E5427FB84DA00489427 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GYMDP69744;
+				GENERATE_INFOPLIST_FILE = YES;
+				IBSC_MODULE = HandsOnWatch_WatchKit_Extension;
+				INFOPLIST_KEY_CFBundleDisplayName = "HandsOnWatch WatchKit App";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Debug;
+		};
+		1BBD6E5527FB84DA00489427 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GYMDP69744;
+				GENERATE_INFOPLIST_FILE = YES;
+				IBSC_MODULE = HandsOnWatch_WatchKit_Extension;
+				INFOPLIST_KEY_CFBundleDisplayName = "HandsOnWatch WatchKit App";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 8.5;
+			};
+			name = Release;
+		};
+		1BBD6E5827FB84DA00489427 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GYMDP69744;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		1BBD6E5927FB84DA00489427 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = GYMDP69744;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.pazzi.marina.HandsOnWatch;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1BBD6E2527FB84D300489427 /* Build configuration list for PBXProject "HandsOnWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1BBD6E4D27FB84DA00489427 /* Debug */,
+				1BBD6E4E27FB84DA00489427 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1BBD6E4F27FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch WatchKit Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1BBD6E5027FB84DA00489427 /* Debug */,
+				1BBD6E5127FB84DA00489427 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1BBD6E5327FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch WatchKit App" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1BBD6E5427FB84DA00489427 /* Debug */,
+				1BBD6E5527FB84DA00489427 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1BBD6E5727FB84DA00489427 /* Build configuration list for PBXNativeTarget "HandsOnWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1BBD6E5827FB84DA00489427 /* Debug */,
+				1BBD6E5927FB84DA00489427 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1BBD6E2227FB84D300489427 /* Project object */;
+}

--- a/HandsOnWatch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HandsOnWatch.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/HandsOnWatch.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/HandsOnWatch.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
*HOTFIXES* 🚨
- Brand primary color corretion
- Changed `.gitignore`
- added .xcodeproj

Created Design Tokens from the Design System of our project. Tokens were created as `Enum` and each with its subdivisions

- Colors
  - Brand
    - `static var primaryColor: Color`
  - Support
    - `static var primaryColor: Color`
    - `static var secondaryColor: Color`
    - `static var tertiaryColor: Color`
    - `static var quaternaryColor: Color`
  - Neutral
    - `static var lowPure: Color`
    - `static var lowDark: Color`
    - `static var lowLight: Color`
    - `static var highPure: Color`
    - `static var highDark: Color`
    - `static var highLight: Color`
- ComponentDimensions
  - Card
    - `static var cardHeight: CGFloat`
- Fonts
  - `static var measures: Font`
  - `static var description: Font`
  - `static var totalTime: Font`
- Border Radius
  - `static var none: CGFloat`
  - `static var sm: CGFloat`
  - `static var pill: CGFloat`
  - `static var circular: CGFloat`
- Icons
  - `static var minusFill: Image`
  - `static var plusFill: Image`
  - `static var xmarkFill: Image`
  - `static var pauseFill: Image`
  - `static var ellipsisFill: Image` 